### PR TITLE
Add index on mktOrders for market speedup

### DIFF
--- a/sql/migrations/202406242143-mktOrderIndex
+++ b/sql/migrations/202406242143-mktOrderIndex
@@ -1,0 +1,5 @@
+-- Adds an index to mktOrders that drastically speeds up market fetching.
+-- +migrate Up
+CREATE INDEX solarSystem on mktOrders(solarSystemID);
+-- +migrate Down
+DROP INDEX solarSystem on mktOrders;


### PR DESCRIPTION
Adds an index on solarSystemID to the mktOrders table, to speed up selects on markets, both regional and system-wide.